### PR TITLE
DESIGN-9 Icon 컴포넌트 추가 (@phosphor-icons/react -> @phosphor-icons/web 전환)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,10 +1,10 @@
-import type { Preview } from "@storybook/react";
-import "../src/styles/bbodek-theme.css";
+import type { Preview } from '@storybook/react';
+import '../src/styles/bbodek-theme.css';
 
 const preview: Preview = {
   parameters: {
-    layout: "centered",
-    actions: { argTypesRegex: "^on[A-Z].*" },
+    layout: 'centered',
+    actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {
       expanded: true,
       matchers: {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "tailwindcss": "3.3.5"
   },
   "dependencies": {
-    "@phosphor-icons/react": "2.0.15",
+    "@phosphor-icons/core": "^2.1.1",
+    "@phosphor-icons/web": "^2.1.1",
     "@toss/use-overlay": "1.3.8",
     "autoprefixer": "10.4.16",
     "clsx": "2.0.0",

--- a/src/core/components/BottomSheet/index.tsx
+++ b/src/core/components/BottomSheet/index.tsx
@@ -1,4 +1,3 @@
-import { X } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { forwardRef, PropsWithChildren } from 'react';
 
@@ -8,6 +7,7 @@ import { VARIANTS } from '../Modal/ModalBase/constants';
 import Section from '../Section';
 import { BottomSheetProps } from './types';
 import useClickOutside from '@/hooks/useClickOutSide';
+import Icon from '@/core/components/Icon';
 
 const BottomSheet = forwardRef(
   (
@@ -22,7 +22,7 @@ const BottomSheet = forwardRef(
   ) => {
     const { contentRef } = useClickOutside<HTMLDivElement>(onClose);
     const { target, className, ...rest } = props;
-    const CloseIcon = <X size='24' fill='#343330' />;
+    const CloseIcon = <Icon className={'text-[1.5rem]'} iconKey={'x'} />;
 
     useBlockScrollingEffect(isOpen);
 

--- a/src/core/components/Calendar/common/subs/CalendarHeader.tsx
+++ b/src/core/components/Calendar/common/subs/CalendarHeader.tsx
@@ -1,9 +1,8 @@
-import { CaretLeft, CaretRight } from '@phosphor-icons/react';
-
 import Typography from '@/core/components/Typography';
 import { MONTH_BUTTON_STATUS } from '../constants';
 import { CalendarHeaderProps } from '../types/CalendarHeader';
 import { getDayjs } from '@/utilities/day';
+import Icon from '@/core/components/Icon';
 
 export const CalendarHeader = ({
   currentMonth,
@@ -35,7 +34,7 @@ export const CalendarHeader = ({
         onClick={() => !isDisablePrev && onPreviousMonthClick?.()}
         disabled={isDisablePrev}
       >
-        <CaretLeft className={iconClassNames} />
+        <Icon iconKey={'caret-left'} className={iconClassNames} />
       </button>
       <div
         className={'flex min-w-[6rem] items-center justify-between text-black'}
@@ -58,7 +57,7 @@ export const CalendarHeader = ({
         onClick={() => !isDisableNext && onNextMonthClick?.()}
         disabled={isDisableNext}
       >
-        <CaretRight className={iconClassNames} />
+        <Icon iconKey={'caret-right'} className={iconClassNames} />
       </button>
     </div>
   );

--- a/src/core/components/Checkbox/Checkbox.stories.tsx
+++ b/src/core/components/Checkbox/Checkbox.stories.tsx
@@ -48,6 +48,6 @@ export const Default = (props: CheckboxProps) => {
   return <Checkbox {...props} />;
 };
 
-export const Circle = () => {
-  return <Checkbox isCircle />;
+export const Circle = (props: CheckboxProps) => {
+  return <Checkbox {...props} isCircle />;
 };

--- a/src/core/components/Checkbox/constants/index.ts
+++ b/src/core/components/Checkbox/constants/index.ts
@@ -16,10 +16,10 @@ export const GAP = {
 } as const;
 
 export const CHECKBOX_SVG_SIZE: Record<SvgSizeType, string> = {
-  [SVG_SIZE['SIZE_32']]: 'w-8 h-8',
-  [SVG_SIZE['SIZE_24']]: 'w-6 h-6',
-  [SVG_SIZE['SIZE_20']]: 'w-5 h-5',
-  [SVG_SIZE['SIZE_16']]: 'w-4 h-4',
+  [SVG_SIZE['SIZE_32']]: 'text-[2rem]',
+  [SVG_SIZE['SIZE_24']]: 'text-[1.5rem]',
+  [SVG_SIZE['SIZE_20']]: 'text-[1.25rem]',
+  [SVG_SIZE['SIZE_16']]: 'text-[1rem',
 };
 
 export const SvgSizeVariants = Object.values(SVG_SIZE);

--- a/src/core/components/Checkbox/index.tsx
+++ b/src/core/components/Checkbox/index.tsx
@@ -1,4 +1,3 @@
-import { CheckCircle, CheckSquare } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import React, { forwardRef, MouseEvent, useId } from 'react';
 
@@ -8,6 +7,7 @@ import { CHECK_BOX_GAP, CHECKBOX_SVG_SIZE, SVG_SIZE } from './constants';
 import { CheckboxProps } from './types';
 import { THEME_COLOR } from '@/constants/color';
 import { ThemeColors } from '@/types';
+import Icon from '@/core/components/Icon';
 
 const Checkbox = forwardRef(
   (
@@ -24,9 +24,6 @@ const Checkbox = forwardRef(
     ref: React.ComponentPropsWithRef<'input'>['ref'],
   ) => {
     const id = useId();
-    const RectangleCheckbox = <CheckSquare size='100%' weight='fill' />;
-    const CircleCheckbox = <CheckCircle size='100%' weight='fill' />;
-    const svg = !isCircle ? RectangleCheckbox : CircleCheckbox;
 
     return (
       <label
@@ -50,11 +47,14 @@ const Checkbox = forwardRef(
           disabled={disabled}
           {...props}
         />
-        <div
-          className={`${CHECKBOX_SVG_SIZE[svgSize]} [&>svg>path]:fill-[#C6CEDE] peer-checked:[&>svg>path]:fill-primary-03`}
-        >
-          {svg}
-        </div>
+        <Icon
+          className={clsx(
+            CHECKBOX_SVG_SIZE[svgSize],
+            'text-gray-05 peer-checked:text-primary-03',
+          )}
+          iconKey={!isCircle ? 'check-square' : 'check-circle'}
+          weight='fill'
+        />
         {label && (
           <Typography
             theme={theme}

--- a/src/core/components/Chip/Chip.stories.tsx
+++ b/src/core/components/Chip/Chip.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/react';
-import { User } from '@phosphor-icons/react';
 import { useState } from 'react';
 
 import { colorThemeOptions } from '@/constants/theme';
@@ -7,6 +6,7 @@ import Chip from './index';
 import { ChipProps } from './types';
 import { ROUNDED } from '@/core/components/Button/ButtonBase/constants';
 import { SIZE } from '@/core/components/Label/constants';
+import Icon from '@/core/components/Icon';
 
 const meta = {
   title: 'core/Chip',
@@ -53,7 +53,7 @@ export const Default = (props: ChipProps<'div'>) => {
         colorTheme={props.colorTheme ?? 'primary'}
         size={props.size ?? 'medium'}
         rounded={props.rounded}
-        icon={<User size={18} />}
+        icon={<Icon iconKey={'user'} className={'text-[1.125rem]'} />}
         onClick={handleClick}
         onDelete={handleDelete}
       />

--- a/src/core/components/Chip/index.tsx
+++ b/src/core/components/Chip/index.tsx
@@ -1,6 +1,5 @@
 import React, { ElementType, forwardRef, MouseEvent } from 'react';
 import clsx from 'clsx';
-import { X } from '@phosphor-icons/react';
 
 import Label from '@/core/components/Label';
 import { ChipProps } from '@/core/components/Chip/types';
@@ -11,6 +10,7 @@ import {
   CHIP_LABEL_STYLE,
 } from '@/core/components/Chip/constants';
 import { COLOR_THEME } from '@/constants/theme';
+import Icon from '@/core/components/Icon';
 
 const Chip = forwardRef(
   <T extends ElementType = 'div'>(
@@ -49,7 +49,7 @@ const Chip = forwardRef(
               'brightness-100 transition-all',
               CHIP_DELETE_BUTTON_STYLE[colorTheme],
             )}
-            icon={<X weight={'bold'} />}
+            icon={<Icon iconKey={'x'} weight={'bold'} />}
             onClick={handleDelete}
           />
         </>

--- a/src/core/components/Chips/Chips.stories.tsx
+++ b/src/core/components/Chips/Chips.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta } from '@storybook/react';
 import { useRef, useState } from 'react';
-import { Plus } from '@phosphor-icons/react';
 
 import Chips from '@/core/components/Chips/index';
 import IconButton from '@/core/components/Button/IconButton';
+import Icon from '@/core/components/Icon';
 
 const meta = {
   title: 'core/Chips',
@@ -31,7 +31,7 @@ export const Default = () => {
         size={'h-29'}
         rounded={'rounded-full'}
         colorTheme={'primary'}
-        icon={<Plus weight={'bold'} />}
+        icon={<Icon iconKey={'plus'} weight={'bold'} />}
         className={'flex-shrink-0'}
         onClick={handleAdd}
       />

--- a/src/core/components/Drawer/index.tsx
+++ b/src/core/components/Drawer/index.tsx
@@ -1,12 +1,12 @@
-import { X } from '@phosphor-icons/react';
 import clsx from 'clsx';
-import { PropsWithChildren, forwardRef } from 'react';
+import { forwardRef, PropsWithChildren } from 'react';
 
 import { useBlockScrollingEffect } from '@/hooks/effects/useBlockScrollingEffect';
 import ModalBase from '../Modal/ModalBase';
 import Section from '../Section';
 import Typography from '../Typography';
 import { DrawerProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const Drawer = forwardRef(
   (
@@ -21,7 +21,7 @@ const Drawer = forwardRef(
     ref: React.Ref<HTMLDialogElement>,
   ) => {
     const { target, className, ...rest } = props;
-    const CloseIcon = <X size='32' fill='#343330' />;
+    const CloseIcon = <Icon className={'text-[2rem]'} iconKey={'x'} />;
 
     useBlockScrollingEffect(isOpen);
 

--- a/src/core/components/Dropdown/DropdownBase/Dropdown.stories.tsx
+++ b/src/core/components/Dropdown/DropdownBase/Dropdown.stories.tsx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/react';
-
-import { CaretDown } from '@phosphor-icons/react';
 import { useState } from 'react';
+
 import DropdownBase from './index';
+import Icon from '@/core/components/Icon';
 
 const meta = {
   title: 'core/Dropdown/DropdownBase',
@@ -53,8 +53,8 @@ export const DropdownBaseWithIcon = () => {
           {({ isToggle }) => (
             <div className='flex items-center'>
               {currentValue || '옵션을 선택해주세요'}
-              <CaretDown
-                size='16'
+              <Icon
+                iconKey={'caret-down'}
                 className={isToggle ? 'rotate-180' : 'rotate-0'}
               />
             </div>
@@ -84,8 +84,8 @@ export const DropdownBaseWithSearch = () => {
           {({ isToggle }) => (
             <div className='flex items-center'>
               {currentValue || '옵션을 선택해주세요'}
-              <CaretDown
-                size='16'
+              <Icon
+                iconKey={'caret-down'}
                 className={isToggle ? 'rotate-180' : 'rotate-0'}
               />
             </div>

--- a/src/core/components/Dropdown/DropdownFilter/DropdownFilterTrigger.tsx
+++ b/src/core/components/Dropdown/DropdownFilter/DropdownFilterTrigger.tsx
@@ -1,9 +1,9 @@
 import { forwardRef } from 'react';
 
-import { CaretDown } from '@phosphor-icons/react';
 import Typography from '../../Typography';
 import DropdownBase from '../DropdownBase';
 import { DropdownFilterTriggerProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const DropdownFilterTrigger = forwardRef(
   (
@@ -19,12 +19,12 @@ const DropdownFilterTrigger = forwardRef(
               color='gray-06'
               text={currentValue}
             />
-            <CaretDown
-              size='16'
+            <Icon
+              iconKey={'caret-down'}
               className={
                 isToggle ? 'rotate-180 text-gray-06' : 'rotate-0 text-gray-06'
               }
-              weight='fill'
+              weight={'fill'}
             />
           </div>
         )}

--- a/src/core/components/Dropdown/DropdownMultiple/DropdownMultipleItem.tsx
+++ b/src/core/components/Dropdown/DropdownMultiple/DropdownMultipleItem.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import { ComponentPropsWithRef, forwardRef, useId } from 'react';
-import { Check } from '@phosphor-icons/react';
 
 import { DropdownMultipleItemProps } from '@/core/components/Dropdown/DropdownMultiple/types';
+import Icon from '@/core/components/Icon';
 
 const DropdownMultipleItem = forwardRef(
   (
@@ -41,11 +41,12 @@ const DropdownMultipleItem = forwardRef(
             readOnly={readOnly}
             {...props}
           />
-          <Check
-            weight='bold'
-            className={clsx(
-              '-mt-[2px] flex-shrink-0 text-gray-03 peer-checked:text-primary-03',
-            )}
+          <Icon
+            iconKey={'check'}
+            className={
+              '-mt-[2px] flex-shrink-0 text-gray-03 peer-checked:text-primary-03'
+            }
+            weight={'bold'}
           />
         </label>
       </li>

--- a/src/core/components/Dropdown/DropdownMultiple/DropdownMultipleTrigger.tsx
+++ b/src/core/components/Dropdown/DropdownMultiple/DropdownMultipleTrigger.tsx
@@ -1,4 +1,3 @@
-import { CaretDown } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { forwardRef, MouseEvent, Ref, useContext } from 'react';
 
@@ -8,6 +7,7 @@ import { DropdownMultipleTriggerProps, ValueWithLabelType } from './types';
 import { DropdownContextValue } from '@/core/components/Dropdown/DropdownBase/types';
 import { DROPDOWN_MULTIPLE_VARIANT } from '@/core/components/Dropdown/DropdownMultiple/constants';
 import Chip from '@/core/components/Chip';
+import Icon from '@/core/components/Icon';
 
 const DropdownMultipleTrigger = forwardRef(
   <T extends ValueWithLabelType>(
@@ -92,10 +92,10 @@ const DropdownMultipleTrigger = forwardRef(
           </ul>
         )}
         {!isDisabled ? (
-          <CaretDown
-            size='24'
+          <Icon
+            iconKey={'caret-down'}
             className={clsx(
-              'flex-shrink-0 text-gray-06',
+              'flex-shrink-0 text-[1.5rem] text-gray-06',
               isVisibleContent ? 'rotate-180' : 'rotate-0',
             )}
             weight='fill'

--- a/src/core/components/Dropdown/DropdownSelect/DropdownSelectTrigger.tsx
+++ b/src/core/components/Dropdown/DropdownSelect/DropdownSelectTrigger.tsx
@@ -1,10 +1,10 @@
-import { CaretDown } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
 
 import Typography from '../../Typography';
 import DropdownBase from '../DropdownBase';
 import { DropdownSelectTriggerProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const DropdownSelectTrigger = forwardRef(
   (
@@ -37,10 +37,10 @@ const DropdownSelectTrigger = forwardRef(
                 text={currentValue ? currentValue : placeholder ?? ''}
               />
               {!isDisabled ? (
-                <CaretDown
-                  size='24'
+                <Icon
+                  iconKey={'caret-down'}
                   className={clsx(
-                    'text-gray-06',
+                    'text-[1.5rem] text-gray-06',
                     isVisibleContent ? 'rotate-180' : 'rotate-0',
                   )}
                   weight='fill'

--- a/src/core/components/Icon/Icon.stories.tsx
+++ b/src/core/components/Icon/Icon.stories.tsx
@@ -1,0 +1,31 @@
+import { icons, IconStyle } from '@phosphor-icons/core';
+import { Meta } from '@storybook/react';
+
+import Icon from '@/core/components/Icon';
+import { IconComponentProps } from '@/core/components/Icon/types';
+
+const meta = {
+  title: 'core/Icon',
+  component: Icon,
+  argTypes: {
+    iconKey: {
+      control: 'select',
+      options: icons.map((icon) => icon['name']),
+      defaultValue: 'acorn',
+      description: '@phosphor-icons/web icon name',
+    },
+    weight: {
+      control: 'select',
+      options: Object.values(IconStyle),
+      defaultValue: IconStyle['REGULAR'],
+      description: '@phosphor-icons/web icon weight',
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+
+export const Default = (props: IconComponentProps) => {
+  return <Icon {...props} className={'h-[2rem] w-[2rem] text-xl'} />;
+};

--- a/src/core/components/Icon/index.tsx
+++ b/src/core/components/Icon/index.tsx
@@ -1,0 +1,31 @@
+import clsx from 'clsx';
+
+import '@phosphor-icons/web/thin';
+import '@phosphor-icons/web/light';
+import '@phosphor-icons/web/regular';
+import '@phosphor-icons/web/bold';
+import '@phosphor-icons/web/fill';
+import '@phosphor-icons/web/duotone';
+
+import { IconComponentProps } from '@/core/components/Icon/types';
+import { IconStyle } from '@phosphor-icons/core';
+
+const Icon = ({ iconKey, weight, className, ...props }: IconComponentProps) => {
+  const iconName = `ph-${iconKey}`;
+  const iconWeight =
+    !weight || weight === IconStyle['REGULAR'] ? 'ph' : `ph-${weight}`;
+
+  return (
+    <span
+      className={clsx(
+        'flex items-center justify-center',
+        iconName,
+        iconWeight,
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export default Icon;

--- a/src/core/components/Icon/types.ts
+++ b/src/core/components/Icon/types.ts
@@ -1,0 +1,7 @@
+import { IconStyle, PhosphorIcon } from '@phosphor-icons/core';
+
+export interface IconComponentProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  iconKey: PhosphorIcon['name'];
+  weight?: `${IconStyle}`;
+}

--- a/src/core/components/Input/InputDatePicker/DatePicker.tsx
+++ b/src/core/components/Input/InputDatePicker/DatePicker.tsx
@@ -1,4 +1,3 @@
-import { CalendarBlank } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { useEffect, useId, useState } from 'react';
 
@@ -10,6 +9,7 @@ import ModalPopUp from '../../Modal/ModalPopUp';
 import GeneralTab from '../../Tab/GeneralTab/GeneralTab';
 import Typography from '../../Typography';
 import { DatePickerProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const DatePicker = ({
   variants = DATE_PICKER_TYPE['PERIOD'],
@@ -87,7 +87,10 @@ const DatePicker = ({
         <header className='p-4'>
           {hasDatePickerTitle && (
             <div className='flex items-center gap-2'>
-              <CalendarBlank className='text-subhead-02-medium md:text-subhead-01-medium' />
+              <Icon
+                iconKey={'calendar-blank'}
+                className={'text-subhead-02-medium md:text-subhead-01-medium'}
+              />
               <Typography
                 element='h6'
                 text='날짜 선택'

--- a/src/core/components/Input/InputDatePicker/index.tsx
+++ b/src/core/components/Input/InputDatePicker/index.tsx
@@ -1,4 +1,3 @@
-import { CalendarBlank } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { HTMLAttributes, useEffect, useId, useState } from 'react';
 
@@ -8,6 +7,7 @@ import InputBase from '../InputBase';
 import DatePicker from './DatePicker';
 import { InputDatePickerProps } from './types';
 import { getDayjs } from '@/utilities/day';
+import Icon from '@/core/components/Icon';
 
 const InputDatePicker = ({
   variants = DATE_PICKER_TYPE['PERIOD'],
@@ -138,7 +138,12 @@ const InputDatePicker = ({
           required={required}
         />
       }
-      endComponent={<CalendarBlank size={24} className='text-gray-05' />}
+      endComponent={
+        <Icon
+          iconKey={'calendar-blank'}
+          className={'text-[1.5rem] text-gray-05'}
+        />
+      }
     />
   );
 };

--- a/src/core/components/Input/InputPassword/index.tsx
+++ b/src/core/components/Input/InputPassword/index.tsx
@@ -2,9 +2,9 @@ import clsx from 'clsx';
 import { forwardRef, useId, useState } from 'react';
 
 import { useInput } from '@/core/components/Input/hooks/useInput';
-import { Eye, EyeSlash } from '@phosphor-icons/react';
 import InputBase from '../InputBase';
 import { InputPasswordProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const InputPassword = forwardRef(
   (
@@ -40,10 +40,6 @@ const InputPassword = forwardRef(
       onChange,
       name,
     });
-    const ShowPasswordIcon = <Eye size={'100%'} weight='fill' fill='#C6CEDE' />;
-    const HidePasswordIcon = (
-      <EyeSlash size={'100%'} weight='fill' fill='#C6CEDE' />
-    );
 
     const onToggleShowPassword = () => setShowPassword((v) => !v);
 
@@ -87,7 +83,11 @@ const InputPassword = forwardRef(
             onClick={onToggleShowPassword}
             aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보이기'}
           >
-            {showPassword ? HidePasswordIcon : ShowPasswordIcon}
+            <Icon
+              weight='fill'
+              className={'text-[1.5rem] text-gray-05'}
+              iconKey={showPassword ? 'eye-slash' : 'eye'}
+            />
           </button>
         }
       />

--- a/src/core/components/Input/InputSearch/index.tsx
+++ b/src/core/components/Input/InputSearch/index.tsx
@@ -1,4 +1,3 @@
-import { MagnifyingGlass } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { useId, useRef } from 'react';
 
@@ -6,6 +5,7 @@ import { useInput } from '@/core/components/Input/hooks/useInput';
 import InputBase from '../InputBase';
 import { INPUT_SEARCH_ROUNDED } from './constants';
 import { InputSearchProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const InputSearch = <T extends React.ElementType = 'form'>({
   formSubmitHandler,
@@ -37,11 +37,18 @@ const InputSearch = <T extends React.ElementType = 'form'>({
     onChange,
     name,
   });
-  const SearchIcon = <MagnifyingGlass size='100%' className='text-gray-05' />;
+
   const el = rootRef.current;
   const isForm = (rootElement || 'form') === 'form';
 
   const endComponent = () => {
+    const SearchIcon = (
+      <Icon
+        iconKey={'magnifying-glass'}
+        className='text-[1.25rem] text-gray-05'
+      />
+    );
+
     if (isForm) {
       return (
         <button className='h-5 w-5' type='submit' aria-label='검색하기'>

--- a/src/core/components/Input/InputTextField/index.tsx
+++ b/src/core/components/Input/InputTextField/index.tsx
@@ -2,9 +2,9 @@ import clsx from 'clsx';
 import { forwardRef, useId } from 'react';
 
 import { useInput } from '@/core/components/Input/hooks/useInput';
-import { XCircle } from '@phosphor-icons/react';
 import InputBase from '../InputBase';
 import { InputTextFieldProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const InputTextField = forwardRef(
   (
@@ -41,7 +41,13 @@ const InputTextField = forwardRef(
       onChange,
       name,
     });
-    const ResetIcon = <XCircle size='100%' weight='fill' fill='#A9B2C7' />;
+    const ResetIcon = (
+      <Icon
+        className={'rounded-full text-[1.75rem] text-gray-05'}
+        iconKey={'x-circle'}
+        weight={'fill'}
+      />
+    );
 
     return (
       <InputBase

--- a/src/core/components/Label/Label.stories.tsx
+++ b/src/core/components/Label/Label.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta } from '@storybook/react';
 
 import { colorThemeOptions } from '@/constants/theme';
-import { Info } from '@phosphor-icons/react';
 import Label from './index';
 import { LabelProps } from './types';
+import Icon from '@/core/components/Icon';
 
 const meta = {
   title: 'core/Label',
@@ -35,7 +35,7 @@ export const Primary = (props: LabelProps) => {
       colorTheme={props.colorTheme ?? 'primary'}
       size='small'
       label={props.label ?? 'small primary'}
-      icon={<Info />}
+      icon={<Icon iconKey={'info'} />}
     />
   );
 };
@@ -46,7 +46,7 @@ export const Error = (props: LabelProps) => {
       colorTheme={props.colorTheme ?? 'error'}
       size='medium'
       label={props.label ?? 'medium error'}
-      icon={<Info />}
+      icon={<Icon iconKey={'info'} />}
     />
   );
 };
@@ -57,7 +57,7 @@ export const Success = (props: LabelProps) => {
       colorTheme={props.colorTheme ?? 'success'}
       size='large'
       label={props.label ?? 'large success'}
-      icon={<Info />}
+      icon={<Icon iconKey={'info'} />}
     />
   );
 };

--- a/src/core/components/Radio/Radio.stories.tsx
+++ b/src/core/components/Radio/Radio.stories.tsx
@@ -2,6 +2,7 @@ import { Meta } from '@storybook/react';
 
 import Radio from './index';
 import { RadioProps } from './types';
+import { SVG_SIZE } from '@/core/components/Radio/constants';
 
 const meta = {
   title: 'core/Radio',
@@ -13,8 +14,8 @@ const meta = {
     },
     svgSize: {
       control: 'select',
-      options: ['18', '24', '32'],
-      defaultValue: '24',
+      options: Object.keys(SVG_SIZE),
+      defaultValue: 'SIZE_24',
       description: 'Radio Icon Size',
     },
   },

--- a/src/core/components/Radio/constants/index.ts
+++ b/src/core/components/Radio/constants/index.ts
@@ -1,5 +1,5 @@
 export const SVG_SIZE = {
-  SIZE_18: 18,
-  SIZE_24: 24,
-  SIZE_32: 32,
+  SIZE_18: 'text-[1.125rem]',
+  SIZE_24: 'text-[1.5rem]',
+  SIZE_32: 'text-[2rem]',
 } as const;

--- a/src/core/components/Radio/index.tsx
+++ b/src/core/components/Radio/index.tsx
@@ -1,14 +1,14 @@
-import { RadioButton } from '@phosphor-icons/react';
 import clsx from 'clsx';
 import { forwardRef, useId } from 'react';
 
 import Typography from '../Typography';
-import { SVG_SIZE } from './constants';
 import { RadioProps } from './types';
+import Icon from '@/core/components/Icon';
+import { SVG_SIZE } from '@/core/components/Radio/constants';
 
 const Radio = forwardRef(
   (
-    { label, svgSize = SVG_SIZE['SIZE_24'], className, ...props }: RadioProps,
+    { label, svgSize = 'SIZE_24', className, ...props }: RadioProps,
     ref: React.ComponentPropsWithRef<'input'>['ref'],
   ) => {
     const id = useId();
@@ -29,13 +29,14 @@ const Radio = forwardRef(
           className='peer hidden'
           {...props}
         />
-        <div
-          className={
-            '[&>svg>path]:fill-[#C6CEDE] peer-checked:[&>svg>path]:fill-primary-03'
-          }
-        >
-          <RadioButton size={svgSize} weight='fill' />
-        </div>
+        <Icon
+          className={clsx(
+            SVG_SIZE[svgSize],
+            'text-gray-05 peer-checked:text-primary-03',
+          )}
+          iconKey={'radio-button'}
+          weight={'fill'}
+        />
         {label && <Typography text={label} />}
       </label>
     );

--- a/src/core/components/Radio/types/index.ts
+++ b/src/core/components/Radio/types/index.ts
@@ -1,9 +1,7 @@
 import { SVG_SIZE } from '../constants';
 
-export type SvgSizeType = (typeof SVG_SIZE)[keyof typeof SVG_SIZE];
-
 export interface RadioProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
-  svgSize?: SvgSizeType;
+  svgSize?: keyof typeof SVG_SIZE;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export { default as Tooltip } from '@/core/components/Tooltip';
 export { default as Typography } from '@/core/components/Typography';
 export { default as Chip } from '@/core/components/Chip';
 export { default as Chips } from '@/core/components/Chips';
+export { default as Icon } from '@/core/components/Icon';
 
 export { useInput } from '@/core/components/Input/hooks/useInput';
 export * from '@/utilities/day';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,10 +1489,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@phosphor-icons/react@2.0.15":
-  version "2.0.15"
-  resolved "https://registry.yarnpkg.com/@phosphor-icons/react/-/react-2.0.15.tgz#4d8e28484d45649f53a6cd75db161cf8b8379e1d"
-  integrity sha512-PQKNcRrfERlC8gJGNz0su0i9xVmeubXSNxucPcbCLDd9u0cwJVTEyYK87muul/svf0UXFdL2Vl6bbeOhT1Mwow==
+"@phosphor-icons/core@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@phosphor-icons/core/-/core-2.1.1.tgz#62a4cfbec9772f1a613a647da214fbb96f3ad39d"
+  integrity sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==
+
+"@phosphor-icons/web@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@phosphor-icons/web/-/web-2.1.1.tgz#a456457f8be17199cb03aa172ce352cc107ae707"
+  integrity sha512-QjrfbItu5Rb2i37GzsKxmrRHfZPTVk3oXSPBnQ2+oACDbQRWGAeB0AsvZw263n1nFouQuff+khOCtRbrc6+k+A==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"


### PR DESCRIPTION
현재 사용중인 Icon 컴포넌트 bbodek-ui 내재화 및 성능 개선을 위해 `@phosphor-icons/react` -> `@phosphor-icons/web & @phosphor-icons/core`로 전환했습니다.

기존 Icon 컴포넌트의 경우 동적으로 아이콘을 불러오기 위해 dynamic을 통한 비동기로 호출해야하는 부분이 있었기에 조금의 성능과 UI/UX을 개선하기 위해 정적 css 파일을 통한 캐싱이점 등의 렌더링 방식으로 적용했습니다.

기존 사용과 변경점은 iconKey를 기존에는 PascalCase로 사용했지만 kebab-case로 사용해야하는점, 사이즈 조절 시 className의 폰트사이즈로 조절해야하는 점이 달라졌습니다.