### PR TITLE
Fix Modal dialog position

### DIFF
--- a/src/core/components/Modal/ModalBase/index.tsx
+++ b/src/core/components/Modal/ModalBase/index.tsx
@@ -33,7 +33,7 @@ const ModalBase = forwardRef(
         <dialog
           ref={ref}
           className={clsx(
-            'h-full w-full overflow-hidden open:animate-fade-in',
+            'left-0 top-0 h-full w-full overflow-hidden open:animate-fade-in',
             MODAL_CONTENT_POSITION[variants],
             dimmed && MODAL_DIMMED_COLOR[variants],
             className,


### PR DESCRIPTION
기존 _document 내  포탈의 컨테이너로 지정하는 `<div id="modal" />`의 위치가 body의 하단으로 내려감에 따라
fixed 의 기본 위치(top...)가 전체 body DOM 하단으로 지정되는 현상이 발생하여 dialog 에 기본 top-0, left-0 을 추가하였습니다.