### PR TITLE
로컬 ngrok 접근 가능 세팅 추가

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,6 +7,9 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     return mergeConfig(config, {
       plugins: [tsconfigPaths()],
+      server: {
+        allowedHosts: ['bbodek.ngrok.io'],
+      },
     });
   },
   addons: [


### PR DESCRIPTION
학부모 팝업 작업 진행하며 테스트 기기 중 아이폰8 기기 로컬 환경에서 peer-checked 부분이 정상 동작하지 않는 부분을 인지하여 확인해 봤으나 명확히 로컬에서만 동작하지 않는 부분은 원인을 찾지 못하였습니다.
(tailwindCSS 자체의 브라우저 지원 확인도 해봤으나 이슈 없음)

개발서버 혹은 프로덕션 환경에서는 정상 동작하고 있기에 더 이상 확인은 진행하지 않고 대신 ngrok 접속을 위한 host 세팅 추가만 진행했습니다.